### PR TITLE
Modify Add Contact submit to navigate to List Details instead of My Lists

### DIFF
--- a/src/screens/AddContactScreen.tsx
+++ b/src/screens/AddContactScreen.tsx
@@ -119,7 +119,7 @@ class AddContactScreen extends React.Component<Props, State> {
 
     try {
       await HoodatService.addContact(listId, name, image, token);
-      this.props.navigation.pop(2);
+      this.props.navigation.goBack();
     } catch (error) {
       Alert.alert('Uh oh!', error.toString());
     }

--- a/src/screens/ListDetailsScreen.tsx
+++ b/src/screens/ListDetailsScreen.tsx
@@ -40,6 +40,7 @@ interface State {
 
 class ListDetailsScreen extends React.Component<Props, State> {
   static contextType = UserContext;
+  private _unsubscribe = () => {};
 
   constructor(props: Props) {
     super(props);
@@ -53,6 +54,20 @@ class ListDetailsScreen extends React.Component<Props, State> {
       menuVisible: false,
       searchQuery: '',
     };
+  }
+
+  async fetchList(): Promise<void> {
+    const { token, userId } = this.context.value;
+
+    try {
+      const list = await HoodatService.getList(
+        this.props.route.params.listId,
+        token
+      );
+      this.setState({ contacts: list.contacts });
+    } catch (error) {
+      Alert.alert('Uh oh!', error.toString());
+    }
   }
 
   async removeList(): Promise<void> {
@@ -83,6 +98,16 @@ class ListDetailsScreen extends React.Component<Props, State> {
     }
 
     return Promise.resolve();
+  }
+
+  componentDidMount() {
+    this._unsubscribe = this.props.navigation.addListener('focus', () => {
+      this.fetchList();
+    });
+  }
+
+  componentWillUnmount() {
+    this._unsubscribe();
   }
 
   render() {

--- a/src/services/HoodatService.ts
+++ b/src/services/HoodatService.ts
@@ -111,6 +111,24 @@ class HoodatService {
     return;
   }
 
+  async getList(listId: string, token: string): Promise<List> {
+    const response = await fetch(`${this.BASE_URL}/lists/${listId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const body = await response.json();
+
+    if (!response.ok) {
+      throw new Error(body.message ?? body.error ?? response.statusText);
+    }
+
+    return body;
+  }
+
   async getLists(userId: string, token: string): Promise<List[]> {
     const response = await fetch(`${this.BASE_URL}/users/${userId}/lists`, {
       method: 'GET',


### PR DESCRIPTION
* Implemented get specific list endpoint so that we don't have to navigate back to My Lists to refresh the List Details screen